### PR TITLE
Slightly change how the label based namespace filter works

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -25,12 +25,12 @@ func NewPod(namespace, name string) v1.Pod {
 }
 
 // NewNamespace returns a new namespace instance for testing purposes.
-func NewNamespace(name string, label string) v1.Namespace {
+func NewNamespace(name string) v1.Namespace {
 	return v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				label: "",
+				"env": name,
 			},
 		},
 	}


### PR DESCRIPTION
Hi @swestcott,

I'm following up with your pull request over at https://github.com/linki/chaoskube/pull/46. I just merged with the latest master and pushed it to your master branch.

However, the next change slightly alters behaviour and I didn't want to push directly to your master branch.

I changed the label-based namespace filtering you contributed a bit: instead of converting and adding it to the namespace selector filter it's now its own "filter-by-all-namespaces-that-match-this-label-selector" function. Not pretty or efficient but does what it should and also solves https://github.com/linki/chaoskube/pull/46#discussion_r151844544.

There's a slight change though: Namespaces are matched against any given label selector first (an empty selector matches all namespaces) and then against the selector based namespace selector as before. This means that given a non-matching label-selector for namespaces will always return an empty pod list. This is different to your version in which case it would match all pods (since there's no namespace to filter by). Refer to the last test in the test cases.

Let me know what you think.

Best regards,
linki